### PR TITLE
Optimise scalar check to succeed fast if the 4th MSB is unset.

### DIFF
--- a/src/main/java/cafe/cryptography/ed25519/Ed25519Signature.java
+++ b/src/main/java/cafe/cryptography/ed25519/Ed25519Signature.java
@@ -44,7 +44,17 @@ public class Ed25519Signature {
         //    signature is invalid.
         // @formatter:on
         CompressedEdwardsY R = new CompressedEdwardsY(Arrays.copyOfRange(input, 0, 32));
-        Scalar S = Scalar.fromCanonicalBytes(Arrays.copyOfRange(input, 32, 64));
+
+        // If the four most significant bits are unset, we know the scalar is
+        // guaranteed to be fully reduced modulo the order of the basepoint, and
+        // thus we can skip the full check.
+        Scalar S;
+        if ((input[63] & 240) == 0) {
+          S = Scalar.fromBits(Arrays.copyOfRange(input, 32, 64));
+        } else {
+          S = Scalar.fromCanonicalBytes(Arrays.copyOfRange(input, 32, 64));
+        }
+
         return new Ed25519Signature(R, S);
     }
 

--- a/src/main/java/cafe/cryptography/ed25519/Ed25519Signature.java
+++ b/src/main/java/cafe/cryptography/ed25519/Ed25519Signature.java
@@ -50,9 +50,9 @@ public class Ed25519Signature {
         // thus we can skip the full check.
         Scalar S;
         if ((input[63] & 240) == 0) {
-          S = Scalar.fromBits(Arrays.copyOfRange(input, 32, 64));
+            S = Scalar.fromBits(Arrays.copyOfRange(input, 32, 64));
         } else {
-          S = Scalar.fromCanonicalBytes(Arrays.copyOfRange(input, 32, 64));
+            S = Scalar.fromCanonicalBytes(Arrays.copyOfRange(input, 32, 64));
         }
 
         return new Ed25519Signature(R, S);

--- a/src/test/java/cafe/cryptography/ed25519/Ed25519SignatureTest.java
+++ b/src/test/java/cafe/cryptography/ed25519/Ed25519SignatureTest.java
@@ -36,4 +36,10 @@ public class Ed25519SignatureTest {
         Ed25519Signature.fromByteArray(Utils.hexToBytes(
                 "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
     }
+
+    @Test
+    public void fromByteArraySucceedsFastS() {
+        Ed25519Signature.fromByteArray(Utils.hexToBytes(
+                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0f"));
+    }
 }


### PR DESCRIPTION
This is only done upon signature deserialisation/verification.
cf. https://github.com/dalek-cryptography/ed25519-dalek/pull/99 for more info.