### PR TITLE
Added @NotNull annotations to improve Kotlin interoperability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ sourceSets {
             // We need the entire source directory here, otherwise we get a
             // "package is empty or does not exist" error during compilation.
             srcDir("src/main/java")
-            include("org.jetbrains.annotations")
             compileClasspath = sourceSets.main.get().compileClasspath
         }
     }
@@ -31,7 +30,9 @@ sourceSets {
 
 dependencies {
     implementation("cafe.cryptography:curve25519-elisabeth:0.1.0")
-    implementation("org.jetbrains:annotations:16.0.2")
+
+    compileOnly("org.jetbrains:annotations:19.0.0")
+
     testImplementation("junit:junit:4.12") {
         exclude("org.hamcrest")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ sourceSets {
             // We need the entire source directory here, otherwise we get a
             // "package is empty or does not exist" error during compilation.
             srcDir("src/main/java")
+            include("org.jetbrains.annotations")
             compileClasspath = sourceSets.main.get().compileClasspath
         }
     }
@@ -30,7 +31,7 @@ sourceSets {
 
 dependencies {
     implementation("cafe.cryptography:curve25519-elisabeth:0.1.0")
-
+    implementation("org.jetbrains:annotations:16.0.2")
     testImplementation("junit:junit:4.12") {
         exclude("org.hamcrest")
     }

--- a/src/main/java/cafe/cryptography/ed25519/Ed25519ExpandedPrivateKey.java
+++ b/src/main/java/cafe/cryptography/ed25519/Ed25519ExpandedPrivateKey.java
@@ -13,6 +13,7 @@ import cafe.cryptography.curve25519.CompressedEdwardsY;
 import cafe.cryptography.curve25519.Constants;
 import cafe.cryptography.curve25519.EdwardsPoint;
 import cafe.cryptography.curve25519.Scalar;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An Ed25519 expanded private key.
@@ -31,6 +32,7 @@ public class Ed25519ExpandedPrivateKey {
      *
      * @return the public key.
      */
+    @NotNull
     public Ed25519PublicKey derivePublic() {
         EdwardsPoint A = Constants.ED25519_BASEPOINT_TABLE.multiply(this.s);
         return new Ed25519PublicKey(A);
@@ -41,7 +43,8 @@ public class Ed25519ExpandedPrivateKey {
      *
      * @return the signature.
      */
-    public Ed25519Signature sign(byte[] message, Ed25519PublicKey publicKey) {
+    @NotNull
+    public Ed25519Signature sign(@NotNull byte[] message, @NotNull Ed25519PublicKey publicKey) {
         return this.sign(message, 0, message.length, publicKey);
     }
 
@@ -50,7 +53,8 @@ public class Ed25519ExpandedPrivateKey {
      *
      * @return the signature.
      */
-    public Ed25519Signature sign(byte[] message, int offset, int length, Ed25519PublicKey publicKey) {
+    @NotNull
+    public Ed25519Signature sign(@NotNull byte[] message, int offset, int length, @NotNull Ed25519PublicKey publicKey) {
         // @formatter:off
         // RFC 8032, section 5.1:
         //   PH(x)   | x (i.e., the identity function)

--- a/src/main/java/cafe/cryptography/ed25519/Ed25519PrivateKey.java
+++ b/src/main/java/cafe/cryptography/ed25519/Ed25519PrivateKey.java
@@ -12,6 +12,7 @@ import java.security.SecureRandom;
 import java.util.Arrays;
 
 import cafe.cryptography.curve25519.Scalar;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An Ed25519 private key.
@@ -31,7 +32,8 @@ public class Ed25519PrivateKey {
      *
      * @return the random private key.
      */
-    public static Ed25519PrivateKey generate(SecureRandom random) {
+    @NotNull
+    public static Ed25519PrivateKey generate(@NotNull SecureRandom random) {
         byte[] secret = new byte[32];
         random.nextBytes(secret);
         return new Ed25519PrivateKey(secret);
@@ -42,7 +44,8 @@ public class Ed25519PrivateKey {
      *
      * @return a private key.
      */
-    public static Ed25519PrivateKey fromByteArray(byte[] secret) {
+    @NotNull
+    public static Ed25519PrivateKey fromByteArray(@NotNull byte[] secret) {
         return new Ed25519PrivateKey(secret);
     }
 
@@ -51,6 +54,7 @@ public class Ed25519PrivateKey {
      *
      * @return the encoded public key.
      */
+    @NotNull
     public byte[] toByteArray() {
         return Arrays.copyOf(this.secret, this.secret.length);
     }
@@ -61,6 +65,7 @@ public class Ed25519PrivateKey {
      *
      * @return the expanded private key.
      */
+    @NotNull
     public Ed25519ExpandedPrivateKey expand() {
         // @formatter:off
         // RFC 8032, section 5.1.6:
@@ -106,6 +111,7 @@ public class Ed25519PrivateKey {
      *
      * @return the public key.
      */
+    @NotNull
     public Ed25519PublicKey derivePublic() {
         return this.expand().derivePublic();
     }

--- a/src/main/java/cafe/cryptography/ed25519/Ed25519PublicKey.java
+++ b/src/main/java/cafe/cryptography/ed25519/Ed25519PublicKey.java
@@ -13,6 +13,7 @@ import cafe.cryptography.curve25519.CompressedEdwardsY;
 import cafe.cryptography.curve25519.EdwardsPoint;
 import cafe.cryptography.curve25519.InvalidEncodingException;
 import cafe.cryptography.curve25519.Scalar;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An Ed25519 public key.
@@ -37,7 +38,8 @@ public class Ed25519PublicKey {
      * @return a public key.
      * @throws InvalidEncodingException if the input is not a valid encoding.
      */
-    public static Ed25519PublicKey fromByteArray(byte[] input) throws InvalidEncodingException {
+    @NotNull
+    public static Ed25519PublicKey fromByteArray(@NotNull byte[] input) throws InvalidEncodingException {
         CompressedEdwardsY Aenc = new CompressedEdwardsY(input);
         return new Ed25519PublicKey(Aenc);
     }
@@ -47,6 +49,7 @@ public class Ed25519PublicKey {
      *
      * @return the encoded public key.
      */
+    @NotNull
     public byte[] toByteArray() {
         return this.Aenc.toByteArray();
     }
@@ -56,7 +59,7 @@ public class Ed25519PublicKey {
      *
      * @return true if the signature is valid, false otherwise.
      */
-    public boolean verify(byte[] message, Ed25519Signature signature) {
+    public boolean verify(@NotNull byte[] message, @NotNull Ed25519Signature signature) {
         return this.verify(message, 0, message.length, signature);
     }
 
@@ -65,7 +68,7 @@ public class Ed25519PublicKey {
      *
      * @return true if the signature is valid, false otherwise.
      */
-    public boolean verify(byte[] message, int offset, int length, Ed25519Signature signature) {
+    public boolean verify(@NotNull byte[] message, int offset, int length, @NotNull Ed25519Signature signature) {
         // @formatter:off
         // RFC 8032, section 5.1:
         //   PH(x)   | x (i.e., the identity function)

--- a/src/main/java/cafe/cryptography/ed25519/Ed25519Signature.java
+++ b/src/main/java/cafe/cryptography/ed25519/Ed25519Signature.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 
 import cafe.cryptography.curve25519.CompressedEdwardsY;
 import cafe.cryptography.curve25519.Scalar;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An Ed25519 signature.
@@ -30,7 +31,8 @@ public class Ed25519Signature {
      *
      * @return a signature.
      */
-    public static Ed25519Signature fromByteArray(byte[] input) {
+    @NotNull
+    public static Ed25519Signature fromByteArray(@NotNull byte[] input) {
         if (input.length != 64) {
             throw new IllegalArgumentException("signature length is wrong");
         }
@@ -53,6 +55,7 @@ public class Ed25519Signature {
      *
      * @return the encoded signature.
      */
+    @NotNull
     public byte[] toByteArray() {
         // RFC 8032, section 5.1.6:
         // @formatter:off

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,3 +1,4 @@
 module cafe.cryptography.ed25519_elisabeth {
     requires cafe.cryptography.curve25519_elisabeth;
+    requires annotations;
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,4 @@
 module cafe.cryptography.ed25519_elisabeth {
     requires cafe.cryptography.curve25519_elisabeth;
-    requires annotations;
+    requires static org.jetbrains.annotations;
 }


### PR DESCRIPTION
This removes the ambiguous Kotlin _platform type_ which asserts that types returned from java are either not nullable or nullable. For example, calling `Ed25519PrivateKey.generate(SecureRandom)` from Kotlin would return an object that is of typed `Ed25519PrivateKey!` which is ambiguously either  `Ed25519PrivateKey` or the nullable `Ed25519PrivateKey?`. 

I went through the library and for all exposed methods that do not return null I've annotated them with `@NotNull`. None of the public methods could return null, but if they did it would be wise to annotate them in a similar fashion with `@Nullable` which informs the k-compiler to explicitly opt for the nullable version of the type. 

Additionally, parameters on public methods with object references that do not use null checks and would throw a NPE if called with `null` in java are also annotated with `@NotNull` which forces the Kotlin compiler to only accept non-null types on those methods and effectively prevents the library from throwing NPEs if used through Kotlin